### PR TITLE
Add `type="button"` to prevent form submission

### DIFF
--- a/src/day.jsx
+++ b/src/day.jsx
@@ -246,6 +246,7 @@ export default class Day extends React.Component {
         ref={r => (this.buttonRef = r)}
         role="option"
         tabIndex="-1"
+        type="button"
       >
         {this.props.renderDayContents
           ? this.props.renderDayContents(


### PR DESCRIPTION
**Please Review** Work done in this PR are as follows:

Error found on UHC UAT: During the Request a Visit flow, when a user selects a date from the react-datepicker when scheduling a visit on a *mouse press*, the form is summited with validation errors. Expected result is the day and time value is added to the input field.

To correct this issue, we added `type="button"` to the `<button>` element to prevent the parent `form` from submitting (a `button` element in a `form` will submit on click by default).

Story: https://teladoc.atlassian.net/browse/UNTD-405