### PR TITLE
Add missing args for `buildAriaLabelText` method

### DIFF
--- a/dist/react-datepicker.js
+++ b/dist/react-datepicker.js
@@ -124,7 +124,7 @@
         e.classNames,
         e.isDate,
         e.isValidDate,
-        e.format$1,
+        e.format,
         e.addMinutes,
         e.addHours,
         e.utils,
@@ -1930,8 +1930,8 @@
               r.join(" ")
             );
           }),
-          se(ue(h), "buildAriaLabelText", function() {
-            h.isDisabledTime(time), ke(time, format, h.props.locale);
+          se(ue(h), "buildAriaLabelText", function(e, t) {
+            h.isDisabledTime(e), ke(e, t, h.props.locale);
           }),
           se(ue(h), "renderTimes", function() {
             var e,
@@ -1970,7 +1970,7 @@
                 f.createElement(
                   "button",
                   ie(
-                    { "aria-label": h.buildAriaLabelText() },
+                    { "aria-label": h.buildAriaLabelText(t, n) },
                     h.isDisabledTime(t) ? { disabled: "disabled" } : "",
                     { onClick: h.handleClick.bind(ue(h), t) }
                   ),

--- a/dist/react-datepicker.min.js
+++ b/dist/react-datepicker.min.js
@@ -124,7 +124,7 @@
         e.classNames,
         e.isDate,
         e.isValidDate,
-        e.format$1,
+        e.format,
         e.addMinutes,
         e.addHours,
         e.utils,
@@ -1930,8 +1930,8 @@
               r.join(" ")
             );
           }),
-          se(ue(h), "buildAriaLabelText", function() {
-            h.isDisabledTime(time), ke(time, format, h.props.locale);
+          se(ue(h), "buildAriaLabelText", function(e, t) {
+            h.isDisabledTime(e), ke(e, t, h.props.locale);
           }),
           se(ue(h), "renderTimes", function() {
             var e,
@@ -1970,7 +1970,7 @@
                 f.createElement(
                   "button",
                   ie(
-                    { "aria-label": h.buildAriaLabelText() },
+                    { "aria-label": h.buildAriaLabelText(t, n) },
                     h.isDisabledTime(t) ? { disabled: "disabled" } : "",
                     { onClick: h.handleClick.bind(ue(h), t) }
                   ),

--- a/es/index.js
+++ b/es/index.js
@@ -3,7 +3,7 @@ import "prop-types";
 import classnames from "classnames";
 import isDate from "date-fns/isDate";
 import isValidDate from "date-fns/isValid";
-import format$1 from "date-fns/format";
+import format from "date-fns/format";
 import addMinutes from "date-fns/addMinutes";
 import addHours from "date-fns/addHours";
 import utils$1 from "date-fns/addDays";
@@ -371,7 +371,7 @@ function parseDate(value, dateFormat, locale, strictParsing) {
         strictParsingValueMatch =
           isValid(tryParseDate) &&
           value ===
-            format$1(tryParseDate, df, {
+            format(tryParseDate, df, {
               awareOfUnicodeTokens: true
             });
       }
@@ -391,7 +391,7 @@ function parseDate(value, dateFormat, locale, strictParsing) {
     strictParsingValueMatch =
       isValid(parsedDate) &&
       value ===
-        format$1(parsedDate, dateFormat, {
+        format(parsedDate, dateFormat, {
           awareOfUnicodeTokens: true
         });
   } else if (!isValid(parsedDate)) {
@@ -428,7 +428,7 @@ function isValid(date) {
 
 function formatDate(date, formatStr, locale) {
   if (locale === "en") {
-    return format$1(date, formatStr, {
+    return format(date, formatStr, {
       awareOfUnicodeTokens: true
     });
   }
@@ -452,7 +452,7 @@ function formatDate(date, formatStr, locale) {
     localeObj = getLocaleObject(getDefaultLocale());
   }
 
-  return format$1(date, formatStr, {
+  return format(date, formatStr, {
     locale: localeObj ? localeObj : null,
     awareOfUnicodeTokens: true
   });
@@ -2859,7 +2859,7 @@ var Time =
       _defineProperty(
         _assertThisInitialized(_this),
         "buildAriaLabelText",
-        function() {
+        function(time, format) {
           _this.isDisabledTime(time)
             ? "".concat(
                 formatDate(time, format, _this.props.locale),
@@ -2922,7 +2922,7 @@ var Time =
               "button",
               _extends(
                 {
-                  "aria-label": _this.buildAriaLabelText()
+                  "aria-label": _this.buildAriaLabelText(time, format)
                 },
                 _this.isDisabledTime(time)
                   ? {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ require("prop-types");
 var classnames = _interopDefault(require("classnames"));
 var isDate = _interopDefault(require("date-fns/isDate"));
 var isValidDate = _interopDefault(require("date-fns/isValid"));
-var format$1 = _interopDefault(require("date-fns/format"));
+var format = _interopDefault(require("date-fns/format"));
 var addMinutes = _interopDefault(require("date-fns/addMinutes"));
 var addHours = _interopDefault(require("date-fns/addHours"));
 var utils = _interopDefault(require("date-fns/addDays"));
@@ -385,7 +385,7 @@ function parseDate(value, dateFormat, locale, strictParsing) {
         strictParsingValueMatch =
           isValid(tryParseDate) &&
           value ===
-            format$1(tryParseDate, df, {
+            format(tryParseDate, df, {
               awareOfUnicodeTokens: true
             });
       }
@@ -405,7 +405,7 @@ function parseDate(value, dateFormat, locale, strictParsing) {
     strictParsingValueMatch =
       isValid(parsedDate) &&
       value ===
-        format$1(parsedDate, dateFormat, {
+        format(parsedDate, dateFormat, {
           awareOfUnicodeTokens: true
         });
   } else if (!isValid(parsedDate)) {
@@ -442,7 +442,7 @@ function isValid(date) {
 
 function formatDate(date, formatStr, locale) {
   if (locale === "en") {
-    return format$1(date, formatStr, {
+    return format(date, formatStr, {
       awareOfUnicodeTokens: true
     });
   }
@@ -466,7 +466,7 @@ function formatDate(date, formatStr, locale) {
     localeObj = getLocaleObject(getDefaultLocale());
   }
 
-  return format$1(date, formatStr, {
+  return format(date, formatStr, {
     locale: localeObj ? localeObj : null,
     awareOfUnicodeTokens: true
   });
@@ -2873,7 +2873,7 @@ var Time =
       _defineProperty(
         _assertThisInitialized(_this),
         "buildAriaLabelText",
-        function() {
+        function(time, format) {
           _this.isDisabledTime(time)
             ? "".concat(
                 formatDate(time, format, _this.props.locale),
@@ -2936,7 +2936,7 @@ var Time =
               "button",
               _extends(
                 {
-                  "aria-label": _this.buildAriaLabelText()
+                  "aria-label": _this.buildAriaLabelText(time, format)
                 },
                 _this.isDisabledTime(time)
                   ? {

--- a/src/time.jsx
+++ b/src/time.jsx
@@ -119,7 +119,7 @@ export default class Time extends React.Component {
     return classes.join(" ");
   };
 
-  buildAriaLabelText = () => {
+  buildAriaLabelText = (time, format) => {
     this.isDisabledTime(time)
       ? `${formatDate(time, format, this.props.locale)} is unavailable`
       : `Select ${formatDate(time, format, this.props.locale)}`;
@@ -173,7 +173,7 @@ export default class Time extends React.Component {
         }}
       >
         <button
-          aria-label={this.buildAriaLabelText()}
+          aria-label={this.buildAriaLabelText(time, format)}
           {...(this.isDisabledTime(time) ? { disabled: "disabled" } : "")}
           onClick={this.handleClick.bind(this, time)}
         >


### PR DESCRIPTION
**Please Review** Work done in this PR are as follows:

QA testing found an issue when testing in the EoD enviroment - when opening the date time picker the section is removed. Issue was found in browser console that a method was missing passing args. This PR correct that issue.

Story: https://teladoc.atlassian.net/browse/UNTD-574